### PR TITLE
TT: [pr13] Use a graph walk for SFPNOP insertion

### DIFF
--- a/gcc/rtl-rvtt-schedule.c
+++ b/gcc/rtl-rvtt-schedule.c
@@ -225,9 +225,7 @@ static void transform ()
 {
   DUMP ("Schedule pass on: %s\n", function_name(cfun));
 
-  // We want to reuse the same vector, to avoid reallocations.
   std::vector<basic_block> visited;
-  visited.reserve (n_basic_blocks_for_fn (cfun));
 
   basic_block bb;
   FOR_EACH_BB_FN (bb, cfun)
@@ -248,8 +246,11 @@ static void transform ()
 		  DUMP ("  dynamic scheduling %s\n", insnd->name);
 		  if (flag_grayskull)
 		    dynamic_schedule_gs (insn);
-		  else
+		  else {
+		    // Reserve space now we know we need it
+		    visited.reserve (n_basic_blocks_for_fn (cfun));
 		    dynamic_schedule_wh_bh (bb, insn, visited);
+		  }
 		}
 	      else if (flag_wormhole || flag_blackhole)
 		{

--- a/gcc/testsuite/g++.target/tt/pr13.C
+++ b/gcc/testsuite/g++.target/tt/pr13.C
@@ -1,0 +1,60 @@
+// Wormhole test to make sure SFPNOPS are inserted, even when the
+// dependency is several BB's away. Somewhat awkward to arrange such a
+// testcase, this is probably fragile
+
+// { dg-do compile }
+// { dg-additional-options "-mwormhole -march=rv32imw -mtune=rvtt-b1 -mabi=ilp32 -O3" }
+
+using vec_t = float __attribute__((vector_size(64 * sizeof(float))));
+
+inline void calculate_power_iterative(unsigned exponent) {
+#pragma GCC unroll 8
+  for (int d = 0; d < 8; d++) {
+    vec_t in = __builtin_rvtt_wh_sfpload(nullptr, 0, 3, 0, 0, 0);
+    vec_t acc = __builtin_rvtt_wh_sfpxloadi(nullptr, 18, 0x3f800000, 0, 0);
+    for (unsigned i = 0; i < exponent; i++)
+      acc = __builtin_rvtt_wh_sfpassign_lv(
+	      acc, __builtin_rvtt_wh_sfpmul(acc, in, 0));
+
+    __builtin_rvtt_wh_sfpstore(nullptr, acc, 12, 3, 0, 0, 0);
+    __builtin_rvtt_sfpincrwc(0, 2, 0, 0);
+  }
+}
+
+inline void llk_math_eltwise_unary_sfpu_params(unsigned dst_index,
+					       int, unsigned arg) {
+#pragma GCC unroll 0
+  for (int face = 0; face < 4; face++)
+    calculate_power_iterative(arg);
+}
+
+inline void llk_math_eltwise_unary_sfpu_power(unsigned dst_index, int pow = 0,
+					      int vector_mode = 4) {
+  llk_math_eltwise_unary_sfpu_params(dst_index, 4, pow);
+}
+
+__attribute__((always_inline))
+inline void power_tile(unsigned, unsigned param0) {
+  llk_math_eltwise_unary_sfpu_power(0, param0);
+}
+  
+extern unsigned *args;
+
+static void math_main() {
+  int ix = 0;
+  const auto height = args[ix++];
+  const auto width = args[ix++];
+  const auto p = args[ix++];
+
+  for (unsigned jx = 0; jx < height; jx++)
+    for (unsigned ix = 0; ix < width; ix++)
+      power_tile(0, p);
+}
+
+void run_kernel() {
+  math_main();
+}
+
+// Same number of SFPMULs as SFPNOPs
+// { dg-final { scan-assembler-times {SFPMUL[^A-Z]} 8 } }
+// { dg-final { scan-assembler-times {SFPNOP[^A-Z]} 8 } }

--- a/gcc/testsuite/g++.target/tt/tt.exp
+++ b/gcc/testsuite/g++.target/tt/tt.exp
@@ -1,0 +1,38 @@
+# Copyright (C) 2024 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GCC; see the file COPYING3.  If not see
+# <http://www.gnu.org/licenses/>.
+
+# GCC testsuite that uses the `dg.exp' driver.
+
+# Exit immediately if this isn't a RISC-V target.
+
+# FIXME: Ideally we'd've stamped these as riscv*-tt-*, but alas
+# not. In lieu of that test the compiler for the tt variants.
+
+if ![istarget riscv*-*-*] then {
+  return
+}
+
+# Load support procs.
+load_lib g++-dg.exp
+
+# Initialize `dg'.
+dg-init
+
+# Main loop.
+dg-runtest [lsort [glob -nocomplain $srcdir/$subdir/*.C]] "" ""
+
+# All done.
+dg-finish


### PR DESCRIPTION
We can't just look at the immediate successor blocks, but must walk the graph until we find a reachable dependent insn. Obviously we need to be careful of loops -- hence marking the visited bbs.  Note that the first BB might itself be reachable, and we want to check it has no use of the result. If we reach a non-dependent SPU insn, we do not need a NOP.

Added a test directory

CI tests are here: https://github.com/tenstorrent/tt-metal/actions/runs/10514586177