### PR TITLE
Reimplement architecture selection

### DIFF
--- a/gcc/common/config/riscv/riscv-common.cc
+++ b/gcc/common/config/riscv/riscv-common.cc
@@ -189,6 +189,10 @@ static const struct riscv_ext_version riscv_ext_version_table[] =
   {"zvl32768b", ISA_SPEC_CLASS_NONE, 1, 0},
   {"zvl65536b", ISA_SPEC_CLASS_NONE, 1, 0},
 
+  {"xttgs", ISA_SPEC_CLASS_NONE, 1, 0},
+  {"xttwh", ISA_SPEC_CLASS_NONE, 1, 0},
+  {"xttbh", ISA_SPEC_CLASS_NONE, 1, 0},
+
   /* Terminate the list.  */
   {NULL, ISA_SPEC_CLASS_NONE, 0, 0}
 };
@@ -1140,7 +1144,10 @@ static const riscv_ext_flag_table_t riscv_ext_flag_table[] =
   {"zvl32768b", &gcc_options::x_riscv_zvl_flags, MASK_ZVL32768B},
   {"zvl65536b", &gcc_options::x_riscv_zvl_flags, MASK_ZVL65536B},
 
-
+  {"xttgs", &gcc_options::x_riscv_tt_flags, MASK_TT_GS},
+  {"xttwh", &gcc_options::x_riscv_tt_flags, MASK_TT_WH},
+  {"xttbh", &gcc_options::x_riscv_tt_flags, MASK_TT_BH},
+  
   {NULL, NULL, 0}
 };
 

--- a/gcc/config/riscv/riscv-c.cc
+++ b/gcc/config/riscv/riscv-c.cc
@@ -64,6 +64,14 @@ riscv_cpu_cpp_builtins (cpp_reader *pfile)
       builtin_define ("__riscv_fsqrt");
     }
 
+  // Unfortunately in the user's namespace
+  if (TARGET_RVTT_GS)
+    builtin_define("ARCH_GRAYSKULL");
+  if (TARGET_RVTT_WH)
+    builtin_define("ARCH_WORMHOLE");
+  if (TARGET_RVTT_BH)
+    builtin_define("ARCH_BLACKHOLE");
+
   switch (riscv_abi)
     {
     case ABI_ILP32E:

--- a/gcc/config/riscv/riscv-cores.def
+++ b/gcc/config/riscv/riscv-cores.def
@@ -47,8 +47,8 @@ RISCV_CORE("sifive-u54",      "rv64imafdc", "sifive-5-series")
 RISCV_CORE("sifive-u74",      "rv64imafdc", "sifive-7-series")
 RISCV_CORE("sifive-u74-sfp",  "rv64imafdcy","sifive-7-series with SFPU")
 
-RISCV_CORE("grayskull",       "rv32iy",     "rvtt-b1")
-RISCV_CORE("wormhole",        "rv32imw",    "rvtt-b1")
-RISCV_CORE("blackhole",       "rv32iml",    "rvtt-b1")
+RISCV_CORE("tt-gs",       "rv32i_xttgs",     "rvtt-b1")
+RISCV_CORE("tt-wh",        "rv32im_xttwh",    "rvtt-b1")
+RISCV_CORE("tt-bh",       "rv32im_xttbh",    "rvtt-b1")
 
 #undef RISCV_CORE

--- a/gcc/config/riscv/riscv-opts.h
+++ b/gcc/config/riscv/riscv-opts.h
@@ -154,4 +154,16 @@ enum stack_protector_guard {
    ? 0 \
    : 32 << (__builtin_popcount (riscv_zvl_flags) - 1))
 
+
+// At-most one bit can be set (attributes are usually independent, hence bits,
+// but that's not how this behaves)
+#define MASK_TT_GS (1 << 0)
+#define MASK_TT_WH (1 << 1)
+#define MASK_TT_BH (1 << 2)
+
+#define TARGET_RVTT_GS ((riscv_tt_flags & MASK_TT_GS) != 0)
+#define TARGET_RVTT_WH ((riscv_tt_flags & MASK_TT_WH) != 0)
+#define TARGET_RVTT_BH ((riscv_tt_flags & MASK_TT_BH) != 0)
+#define TARGET_RVTT (riscv_tt_flags != 0)
+
 #endif /* ! GCC_RISCV_OPTS_H */

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -5178,6 +5178,8 @@ riscv_option_override (void)
       riscv_stack_protector_guard_offset = offs;
     }
 
+  if (int(TARGET_RVTT_GS) + int(TARGET_RVTT_WH) + int(TARGET_RVTT_BH) > 1)
+    error ("only one ttgs, ttwh or ttbh extension can be specified");
 }
 
 /* Implement TARGET_CONDITIONAL_REGISTER_USAGE.  */

--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -104,19 +104,13 @@ extern const char *riscv_default_mtune (int argc, const char **argv);
 %{mbig-endian} \
 %{mlittle-endian} \
 %(subtarget_asm_spec) \
-%(subtarget_asm_spec) \
-%{mgrayskull:} \
-%{mwormhole:-mwormhole} \
-%{mblackhole:-mblackhole} " \
+%(subtarget_asm_spec)" \
 ASM_MISA_SPEC
 
 #undef DRIVER_SELF_SPECS
 #define DRIVER_SELF_SPECS					\
 "%{march=*:%:riscv_expand_arch(%*)} "				\
-"%{!march=*:%{mcpu=*:%:riscv_expand_arch_from_cpu(%*)}} "       \
-"%{mgrayskull:-mgrayskull} "					\
-"%{mwormhole:-mwormhole} "					\
-"%{mblackhole:-mblackhole} "
+"%{!march=*:%{mcpu=*:%:riscv_expand_arch_from_cpu(%*)}} "
 
 #define TARGET_DEFAULT_CMODEL CM_MEDLOW
 

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -78,21 +78,9 @@ mdiv
 Target Mask(DIV)
 Use hardware instructions for integer division.
 
-;mgrayskull
-;Target Mask(RVTT_GS) Bool Var(flag_grayskull) Init(0)
-;Generate code for Tenstorrent SFPU - Grayskull.
-
-;mwormhole
-;Target Mask(RVTT_WH) Bool Var(flag_wormhole) Init(0)
-;Generate code for Tenstorrent SFPU - Wormhole.
-
 mwormhole_a0
 Target Bool Var(flag_wormhole_a0) Init(0)
 Generate code for Tenstorrent SFPU - Wormhole a0 Si.
-
-;mblackhole
-;Target Mask(RVTT_BH) Bool Var(flag_blackhole) Init(0)
-;Generate code for Tenstorrent SFPU - Blackhole.
 
 march=
 Target RejectNegative Joined Negative(march=)

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -78,21 +78,21 @@ mdiv
 Target Mask(DIV)
 Use hardware instructions for integer division.
 
-mgrayskull
-Target Mask(RVTT_GS) Bool Var(flag_grayskull) Init(0)
-Generate code for Tenstorrent SFPU - Grayskull.
+;mgrayskull
+;Target Mask(RVTT_GS) Bool Var(flag_grayskull) Init(0)
+;Generate code for Tenstorrent SFPU - Grayskull.
 
-mwormhole
-Target Mask(RVTT_WH) Bool Var(flag_wormhole) Init(0)
-Generate code for Tenstorrent SFPU - Wormhole.
+;mwormhole
+;Target Mask(RVTT_WH) Bool Var(flag_wormhole) Init(0)
+;Generate code for Tenstorrent SFPU - Wormhole.
 
 mwormhole_a0
 Target Bool Var(flag_wormhole_a0) Init(0)
 Generate code for Tenstorrent SFPU - Wormhole a0 Si.
 
-mblackhole
-Target Mask(RVTT_BH) Bool Var(flag_blackhole) Init(0)
-Generate code for Tenstorrent SFPU - Blackhole.
+;mblackhole
+;Target Mask(RVTT_BH) Bool Var(flag_blackhole) Init(0)
+;Generate code for Tenstorrent SFPU - Blackhole.
 
 march=
 Target RejectNegative Joined Negative(march=)
@@ -224,6 +224,9 @@ int riscv_vector_elen_flags
 
 TargetVariable
 int riscv_zvl_flags
+
+TargetVariable
+int riscv_tt_flags
 
 Enum
 Name(isa_spec_class) Type(enum riscv_isa_spec_class)

--- a/gcc/config/riscv/rvtt.cc
+++ b/gcc/config/riscv/rvtt.cc
@@ -161,13 +161,13 @@ rvtt_insert_insn(int idx, const char* name, tree decl)
   static int start = 0;
 
   int arch;
-  if (flag_grayskull) {
+  if (TARGET_RVTT_GS) {
     arch = 0;
     rvtt_sfpu_lreg_count_global = SFPU_LREG_COUNT_GS;
-  } else if (flag_wormhole) {
+  } else if (TARGET_RVTT_WH) {
     arch = 1;
     rvtt_sfpu_lreg_count_global = SFPU_LREG_COUNT_WH;
-  } else if (flag_blackhole) {
+  } else if (TARGET_RVTT_BH) {
     arch = 2;
     rvtt_sfpu_lreg_count_global = SFPU_LREG_COUNT_BH;
   } else {
@@ -247,13 +247,13 @@ void
 rvtt_init_builtins()
 {
   int arch;
-  if (flag_grayskull) {
+  if (TARGET_RVTT_GS) {
     arch = 0;
     rvtt_builtin_name_stub = "__builtin_rvtt_gs";
-  } else if (flag_wormhole) {
+  } else if (TARGET_RVTT_WH) {
     arch = 1;
     rvtt_builtin_name_stub = "__builtin_rvtt_wh";
-  } else if (flag_blackhole) {
+  } else if (TARGET_RVTT_BH) {
     arch = 2;
     rvtt_builtin_name_stub = "__builtin_rvtt_bh";
   } else {
@@ -565,7 +565,7 @@ char const * rvtt_output_nonimm_and_nops(const char *sw, int nnops, rtx operands
 {
   // Replay pass on wormhole/blackhole assumes insns only emit 1 insn
   nnops &= INSN_SCHED_NOP_MASK;
-  gcc_assert(flag_wormhole == 0 || flag_blackhole == 0 || nnops == 0);
+  gcc_assert(!TARGET_RVTT_WH || !TARGET_RVTT_BH || nnops == 0);
   char const *out = sw;
   while (nnops-- > 0) {
      output_asm_insn(out, operands);

--- a/gcc/doc/invoke.texi
+++ b/gcc/doc/invoke.texi
@@ -27988,7 +27988,7 @@ by particular CPU name.
 Permissible values for this option are: @samp{sifive-e20}, @samp{sifive-e21},
 @samp{sifive-e24}, @samp{sifive-e31}, @samp{sifive-e34}, @samp{sifive-e76},
 @samp{sifive-s21}, @samp{sifive-s51}, @samp{sifive-s54}, @samp{sifive-s76},
-@samp{sifive-u54}, and @samp{sifive-u74}.
+@samp{sifive-u54}, @samp{sifive-u74}, @samp{tt-gs}, @samp{tt-wh} and @samp{tt-bh}.
 
 @item -mtune=@var{processor-string}
 @opindex mtune

--- a/gcc/gimple-rvtt-attrib.cc
+++ b/gcc/gimple-rvtt-attrib.cc
@@ -248,10 +248,8 @@ public:
 unsigned int
 pass_rvtt_attrib::execute (function *fun)
 {
-  if (flag_grayskull || flag_wormhole)
-    {
-      transform (fun);
-    }
+  if (TARGET_RVTT_GS || TARGET_RVTT_WH)
+    transform (fun);
 
   return 0;
 }

--- a/gcc/gimple-rvtt-cc.cc
+++ b/gcc/gimple-rvtt-cc.cc
@@ -311,10 +311,8 @@ public:
 unsigned int
 pass_rvtt_cc::execute (function *fun)
 {
-  if (flag_rvtt_cc && (flag_grayskull || flag_wormhole || flag_blackhole))
-    {
-      transform (fun);
-    }
+  if (flag_rvtt_cc && TARGET_RVTT)
+    transform (fun);
 
   return 0;
 }

--- a/gcc/gimple-rvtt-combine.cc
+++ b/gcc/gimple-rvtt-combine.cc
@@ -485,7 +485,7 @@ try_gen_mad(const rvtt_insn_data *candidate_insnd,
 
 	  tree assign_lhs = gimple_call_lhs(assign_stmt);
 
-	  if (!intervening_unrelated_or_cc_stmt(gimple_call_arg(candidate_stmt, live + which_arg ^ 1),
+	  if (!intervening_unrelated_or_cc_stmt(gimple_call_arg(candidate_stmt, (live + which_arg) ^ 1),
 						assign_gsi, candidate_gsi) &&
 	      has_single_use(assign_lhs))
 	    {
@@ -787,7 +787,7 @@ static void transform (function *fun)
     {
       bool update = false;
 
-      if (flag_grayskull) {
+      if (TARGET_RVTT_GS) {
 	candidate_gsi = gsi_start_bb (bb);
 	while (!gsi_end_p (candidate_gsi))
 	  {
@@ -881,10 +881,8 @@ public:
 unsigned int
 pass_rvtt_combine::execute (function *fun)
 {
-  if (flag_rvtt_combine && (flag_grayskull || flag_wormhole || flag_blackhole))
-    {
-      transform (fun);
-    }
+  if (flag_rvtt_combine && TARGET_RVTT)
+    transform (fun);
 
   return 0;
 }

--- a/gcc/gimple-rvtt-expand.cc
+++ b/gcc/gimple-rvtt-expand.cc
@@ -207,14 +207,10 @@ emit_pushc(gimple_stmt_iterator *gsip, gcall *stmt, bool insert_before)
   const rvtt_insn_data *new_insnd =
     rvtt_get_insn_data(rvtt_insn_data::sfppushc);
   gimple *new_stmt;
-  if (flag_grayskull)
-    {
-      new_stmt = gimple_build_call(new_insnd->decl, 0);
-    }
+  if (TARGET_RVTT_GS)
+    new_stmt = gimple_build_call(new_insnd->decl, 0);
   else
-    {
-      new_stmt = gimple_build_call(new_insnd->decl, 1, size_int(SFPPUSHCC_MOD1_PUSH));
-    }
+    new_stmt = gimple_build_call(new_insnd->decl, 1, size_int(SFPPUSHCC_MOD1_PUSH));
   finish_new_insn(gsip, insert_before, new_stmt, stmt);
 }
 
@@ -224,14 +220,10 @@ emit_popc(gimple_stmt_iterator *gsip, gcall *stmt, bool insert_before)
   const rvtt_insn_data *new_insnd =
     rvtt_get_insn_data(rvtt_insn_data::sfppopc);
   gimple *new_stmt;
-  if (flag_grayskull)
-    {
-      new_stmt = gimple_build_call(new_insnd->decl, 0);
-    }
+  if (TARGET_RVTT_GS)
+    new_stmt = gimple_build_call(new_insnd->decl, 0);
   else
-    {
-      new_stmt = gimple_build_call(new_insnd->decl, 1, size_int(SFPPOPCC_MOD1_POP));
-    }
+    new_stmt = gimple_build_call(new_insnd->decl, 1, size_int(SFPPOPCC_MOD1_POP));
   finish_new_insn(gsip, insert_before, new_stmt, stmt);
 }
 
@@ -746,10 +738,8 @@ public:
 unsigned int
 pass_rvtt_expand::execute (function *fun)
 {
-  if (flag_grayskull || flag_wormhole || flag_blackhole)
-    {
-      transform (fun);
-    }
+  if (TARGET_RVTT)
+    transform (fun);
 
   return 0;
 }

--- a/gcc/gimple-rvtt-live.cc
+++ b/gcc/gimple-rvtt-live.cc
@@ -680,10 +680,8 @@ public:
 unsigned int
 pass_rvtt_live::execute (function *fun)
 {
-  if (flag_grayskull || flag_wormhole || flag_blackhole)
-    {
-      transform (fun);
-    }
+  if (TARGET_RVTT)
+    transform (fun);
 
   return 0;
 }

--- a/gcc/gimple-rvtt-move.cc
+++ b/gcc/gimple-rvtt-move.cc
@@ -301,10 +301,8 @@ public:
 unsigned int
 pass_rvtt_move::execute (function *fun)
 {
-  if (flag_grayskull || flag_wormhole || flag_blackhole)
-    {
-      transform (fun);
-    }
+  if (TARGET_RVTT)
+    transform (fun);
 
   return 0;
 }

--- a/gcc/gimple-rvtt-nonimm-tag.cc
+++ b/gcc/gimple-rvtt-nonimm-tag.cc
@@ -170,10 +170,8 @@ public:
 unsigned int
 pass_rvtt_nonimm_tag::execute (function *fun)
 {
-  if (flag_grayskull || flag_wormhole || flag_blackhole)
-    {
-      transform (fun);
-    }
+  if (TARGET_RVTT)
+    transform (fun);
   return 0;
 }
 

--- a/gcc/gimple-rvtt-warn.cc
+++ b/gcc/gimple-rvtt-warn.cc
@@ -117,7 +117,7 @@ warn_replace_stmt(gimple_stmt_iterator *gsi, tree lhs, location_t loc)
 
   gimple_set_location (loadi_use_stmt, loc);
   update_stmt(loadi_use_stmt);
-  gsi_replace(gsi, loadi_use_stmt, GSI_SAME_STMT);
+  gsi_replace(gsi, loadi_use_stmt, false);
   update_ssa (TODO_update_ssa);
 }
 
@@ -375,11 +375,9 @@ public:
 unsigned int
 pass_rvtt_warn::execute (function *fun)
 {
-  bool sfpu_warn = (flag_rvtt_warn && (flag_grayskull || flag_wormhole || flag_blackhole));
+  bool sfpu_warn = flag_rvtt_warn && TARGET_RVTT;
   if (sfpu_warn || flag_rvtt_error_multdiv)
-    {
-      process (fun, sfpu_warn, flag_rvtt_error_multdiv);
-    }
+    process (fun, sfpu_warn, flag_rvtt_error_multdiv);
 
   return 0;
 }

--- a/gcc/rtl-rvtt-hll.cc
+++ b/gcc/rtl-rvtt-hll.cc
@@ -687,7 +687,7 @@ workaround_gswh_raw(function *cfn)
 		      if (!rvtt_reg_store_p(insn_pat))
 			{
 			  // Use the same register as used in the insn if we need th hll war
-			  war_regno = (flag_grayskull && rvtt_l1_store_p(insn_pat)) ?
+			  war_regno = (TARGET_RVTT_GS && rvtt_l1_store_p(insn_pat)) ?
 			    REGNO(SET_SRC(insn_pat)) : 0;
 			  int dummy_offset;
 			  get_mem_reg_and_offset(SET_DEST(insn_pat), &war_ptr_regno, &dummy_offset);
@@ -1990,10 +1990,8 @@ void analysis::print()
   fprintf(stderr, "Stack lds: %d\n", n_stack_lds);
   fprintf(stderr, "Stack sts: %d\n", n_stack_sts);
   if (n_sfpu != 0) fprintf(stderr, "SFPU: %d\n", n_sfpu);
-  if (flag_grayskull && flag_rvtt_gshllwar)
-    {
-      fprintf(stderr, "GS arbiter wars: %d\n", n_gs_hll_wars);
-    }
+  if (TARGET_RVTT_GS && flag_rvtt_gshllwar)
+    fprintf(stderr, "GS arbiter wars: %d\n", n_gs_hll_wars);
   fprintf(stderr, "Cycles top to bottom: %d\n", cycle_count);
 }
 
@@ -2046,15 +2044,11 @@ public:
 	}
 
       // This must come before the hll pass as it introduces loads
-      if (flag_grayskull || flag_wormhole)
-	{
-	  workaround_gswh_raw(cfn);
-	}
+      if (TARGET_RVTT_GS || TARGET_RVTT_WH)
+	workaround_gswh_raw(cfn);
 
-      if (flag_grayskull && flag_rvtt_gshllwar)
-	{
-	  workaround_gs_hll(cfn);
-	}
+      if (TARGET_RVTT_GS && flag_rvtt_gshllwar)
+	workaround_gs_hll(cfn);
 
       return 0;
     }

--- a/gcc/rtl-rvtt-nonimm.cc
+++ b/gcc/rtl-rvtt-nonimm.cc
@@ -255,10 +255,8 @@ public:
   /* opt_pass methods: */
   virtual unsigned int execute (function *cfn)
     {
-      if (flag_grayskull || flag_wormhole || flag_blackhole)
-       {
-	 transform (cfn);
-       }
+      if (TARGET_RVTT)
+	transform (cfn);
       return 0;
     }
 }; // class pass_rvtt_nonimm

--- a/gcc/rtl-rvtt-replay.cc
+++ b/gcc/rtl-rvtt-replay.cc
@@ -629,11 +629,11 @@ static bool do_update(bool first, int i, int count, int length,
 	{
 	  DUMP("    inserting replay capture at %d\n", i - count);
 	  first = false;
-	  if (flag_wormhole) {
+	  if (TARGET_RVTT_WH) {
 	    emit_insn_before(gen_rvtt_wh_sfpreplay(GEN_INT(0), GEN_INT(count),
 						   GEN_INT(1), GEN_INT(1)),
 			     start_insn);
-	  } else if (flag_blackhole) {
+	  } else if (TARGET_RVTT_BH) {
 	    emit_insn_before(gen_rvtt_bh_sfpreplay(GEN_INT(0), GEN_INT(count),
 						   GEN_INT(1), GEN_INT(1)),
 			     start_insn);
@@ -654,11 +654,11 @@ static bool do_update(bool first, int i, int count, int length,
 	    }
 	  start_insn = NEXT_INSN(start_insn);
 	}
-      if (flag_wormhole) {
+      if (TARGET_RVTT_WH) {
 	emit_insn_before(gen_rvtt_wh_sfpreplay(GEN_INT(0), GEN_INT(count),
 					       GEN_INT(0), GEN_INT(0)),
 			 insn);
-      } else if (flag_blackhole) {
+      } else if (TARGET_RVTT_BH) {
 	emit_insn_before(gen_rvtt_bh_sfpreplay(GEN_INT(0), GEN_INT(count),
 					       GEN_INT(0), GEN_INT(0)),
 			 insn);
@@ -828,7 +828,7 @@ public:
   /* opt_pass methods: */
   virtual unsigned int execute (function *cfn)
     {
-      if (((flag_wormhole && !flag_wormhole_a0) || flag_blackhole) && flag_rvtt_replay)
+      if (flag_rvtt_replay && ((TARGET_RVTT_WH && !flag_wormhole_a0) || TARGET_RVTT_BH))
 	{
 	  replay_max_insns = rvtt_replay_buffer_size;
 	  transform (cfn);

--- a/gcc/rtl-rvtt-schedule.cc
+++ b/gcc/rtl-rvtt-schedule.cc
@@ -74,11 +74,11 @@ insert_nop_after (rtx_insn *insn)
 {
   rtx nop = NULL_RTX;
 
-  if (flag_grayskull)
+  if (TARGET_RVTT_GS)
     nop = gen_rvtt_gs_sfpnop();
-  else if (flag_wormhole)
+  else if (TARGET_RVTT_WH)
     nop = gen_rvtt_wh_sfpnop();
-  else if (flag_blackhole)
+  else if (TARGET_RVTT_BH)
     nop = gen_rvtt_bh_sfpnop();
   else
     gcc_unreachable ();
@@ -244,7 +244,7 @@ static void transform ()
 	      if (insnd->schedule_dynamic_p (insn))
 		{
 		  DUMP ("  dynamic scheduling %s\n", insnd->name);
-		  if (flag_grayskull)
+		  if (TARGET_RVTT_GS)
 		    dynamic_schedule_gs (insn);
 		  else {
 		    // Reserve space now we know we need it
@@ -252,7 +252,7 @@ static void transform ()
 		    dynamic_schedule_wh_bh (bb, insn, visited);
 		  }
 		}
-	      else if (flag_wormhole || flag_blackhole)
+	      else if (TARGET_RVTT_WH || TARGET_RVTT_BH)
 		{
 		  DUMP ("  static scheduling %s\n", insnd->name);
 		  int count = insnd->schedule_static_nops (insn);
@@ -295,10 +295,8 @@ public:
 unsigned int
 pass_rvtt_schedule::execute (function *)
 {
-  if (flag_grayskull || flag_wormhole || flag_blackhole)
-    {
-      transform ();
-    }
+  if (TARGET_RVTT)
+    transform ();
 
   return 0;
 }

--- a/gcc/testsuite/g++.target/tt/pr13.C
+++ b/gcc/testsuite/g++.target/tt/pr13.C
@@ -3,7 +3,7 @@
 // testcase, this is probably fragile
 
 // { dg-do compile }
-// { dg-additional-options "-mwormhole -march=rv32imw -mtune=rvtt-b1 -mabi=ilp32 -O3" }
+// { dg-additional-options "-mcpu=tt-wh -mabi=ilp32 -O3" }
 
 using vec_t = float __attribute__((vector_size(64 * sizeof(float))));
 

--- a/gcc/testsuite/g++.target/tt/raw-race-1.C
+++ b/gcc/testsuite/g++.target/tt/raw-race-1.C
@@ -1,5 +1,5 @@
 // { dg-do compile }
-// { dg-additional-options "-mwormhole -march=rv32imw -mtune=rvtt-b1 -mabi=ilp32 -fno-inline -O2 -fno-exceptions" }
+// { dg-additional-options "-mcpu=tt-wh -mabi=ilp32 -fno-inline -O2 -fno-exceptions" }
 
 // Read after write race with different sized accesses and different
 // effective addresses.


### PR DESCRIPTION

This implements riscv-conformant architecture selection. The bulk of the work is in binutils. in GCC we

    remove -mgrayskull, -mwormhole, -mblackhole options
    add -mcpu=tt-gs, -mcpu=tt-wh, -mcpu=tt-bh cpus
    (the assembler replaces the yw &l arch variants with xttgs, xttwh & xttbh variants.

The simplest way to drive the compiler now is -mcpu=tt-CPU, not -march=rv32i$VARIANT -mVARIANT.
