### PR TITLE
SFPSTORE const bug.

### DIFF
--- a/sfpstore-const.md
+++ b/sfpstore-const.md
@@ -1,0 +1,12 @@
+The following code:
+
+```cpp
+sfpi::vFloat tmp = sfpi::vConstFloatPrgm0;
+dst_reg[0] = tmp;
+```
+
+Incorrectly generates the following, which is a no-op as SFPSTORE only works with L0-L11
+
+```asm
+sfpstore  0,L12,0,3
+```


### PR DESCRIPTION
The following code:

```cpp
sfpi::vFloat tmp = sfpi::vConstFloatPrgm0;
dst_reg[0] = tmp;
```

Incorrectly generates the following, which is a no-op as SFPSTORE normally only works with L0-L11 [ref](https://github.com/tenstorrent/tt-isa-documentation/blob/main/WormholeB0/TensixTile/TensixCoprocessor/SFPSTORE.md#functional-model):

```asm
sfpstore  0,L12,0,3
```