### PR TITLE
#25192 Tune integer multiply/divide cost for different architectures

### DIFF
--- a/gcc/config/riscv/riscv-cores.def
+++ b/gcc/config/riscv/riscv-cores.def
@@ -44,7 +44,11 @@ RISCV_TUNE("thead-c906", generic, thead_c906_tune_info)
 RISCV_TUNE("xiangshan-nanhu", xiangshan, xiangshan_nanhu_tune_info)
 RISCV_TUNE("generic-ooo", generic_ooo, generic_ooo_tune_info)
 RISCV_TUNE("size", generic, optimize_size_tune_info)
+
+// TODO: Update instruction scheduling tuning
 RISCV_TUNE("rvtt-b1", rvtt_b1, rvtt_b1_tune_info)
+RISCV_TUNE("rvtt-qsr32", rvtt_b1, rvtt_qsr32_tune_info)
+RISCV_TUNE("rvtt-qsr64", rvtt_b1, rvtt_qsr64_tune_info)
 
 #undef RISCV_TUNE
 
@@ -111,16 +115,14 @@ RISCV_CORE("tt-wh-tensix",    "rv32im_xtttensixwh", "ilp32", "rvtt-b1")
 RISCV_CORE("tt-bh",           "rv32im_zaamo_zba_zbb", "ilp32", "rvtt-b1")
 RISCV_CORE("tt-bh-tensix",    "rv32im_zaamo_zba_zbb_xtttensixbh", "ilp32", "rvtt-b1")
 
-// TODO update tune parameter
-
 // #31429 disable compressed 'c' extension, it interfers with our post-processing.
-RISCV_CORE("tt-qsr64",        "rv64imab_zicond_zicsr_zifencei_zihpm_xttcache", "lp64", "rvtt-b1")
-RISCV_CORE("tt-qsr64-rocc",   "rv64imab_zicond_zicsr_zifencei_zihpm_xttcache_xttroccqsr", "lp64", "rvtt-b1")
+RISCV_CORE("tt-qsr64",        "rv64imab_zicond_zicsr_zifencei_zihpm_xttcache", "lp64", "rvtt-qsr64")
+RISCV_CORE("tt-qsr64-rocc",   "rv64imab_zicond_zicsr_zifencei_zihpm_xttcache_xttroccqsr", "lp64", "rvtt-qsr64")
 
 // #39314 disable float 'f' extension, tt-sim doesn't grok them
 // #35991 disable vector 'v' extension, tt-sim doesn't grok them, it's not on all compute cores anyway
-RISCV_CORE("tt-qsr32",          "rv32im_zaamo","ilp32", "rvtt-b1")
-RISCV_CORE("tt-qsr32-tensix",   "rv32im_zaamo_xtttensixqsr", "ilp32", "rvtt-b1")
-RISCV_CORE("tt-qsr32-tensixbh", "rv32im_zaamo_xtttensixbh", "ilp32", "rvtt-b1")
+RISCV_CORE("tt-qsr32",          "rv32im_zaamo","ilp32", "rvtt-qsr32")
+RISCV_CORE("tt-qsr32-tensix",   "rv32im_zaamo_xtttensixqsr", "ilp32", "rvtt-qsr32")
+RISCV_CORE("tt-qsr32-tensixbh", "rv32im_zaamo_xtttensixbh", "ilp32", "rvtt-qsr32")
 
 #undef RISCV_CORE

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -647,12 +647,66 @@ static const struct riscv_tune_param optimize_size_tune_info = {
   NULL,						/* loop_align */
 };
 
-/* Costs to use when optimizing for rvtt_b1.  */
+/* The int_mul/int_div values below are not raw latencies; they are
+costs that are used to compare alternative code sequences.
+In particular, GCC decides whether to replace division-by-constant with a
+multiply+shift chain by comparing the total cost of that chain against a 
+single int_div. */
+
+/* Costs to use when optimizing for rvtt_b1 (wormhole / blackhole).
+   HW latencies: multiply 2 cycles, divide variable 6-33 cycles. */
 static const struct riscv_tune_param rvtt_b1_tune_info = {
   {COSTS_N_INSNS (0), COSTS_N_INSNS (0)},	/* fp_add NA */
   {COSTS_N_INSNS (0), COSTS_N_INSNS (0)},	/* fp_mul NA */
   {COSTS_N_INSNS (0), COSTS_N_INSNS (0)},	/* fp_div NA */
-  {COSTS_N_INSNS (4), COSTS_N_INSNS (4)},	/* int_mul */
+  {COSTS_N_INSNS (2), COSTS_N_INSNS (2)},	/* int_mul */
+  {COSTS_N_INSNS (20), COSTS_N_INSNS (20)},	/* int_div */
+  1,						/* issue_rate */
+  5,						/* branch_cost - theory says 4, 5 performs better 12/12/22 */
+  5,						/* memory_cost */
+  8,						/* fmv_cost */
+  true,						/* slow_unaligned_access */
+  false,					/* vector_unaligned_access */
+  false,					/* use_divmod_expansion */
+  false,					/* overlap_op_by_pieces */
+  RISCV_FUSE_NOTHING,                           /* fusible_ops */
+  NULL,						/* vector cost */
+  NULL,						/* function_align */
+  NULL,						/* jump_align */
+  NULL,						/* loop_align */
+};
+
+/* Costs to use when optimizing for qsr32.
+   HW latencies: multiply 2 cycles, divide 3 cycles (fixed).  */
+static const struct riscv_tune_param rvtt_qsr32_tune_info = {
+  {COSTS_N_INSNS (0), COSTS_N_INSNS (0)},	/* fp_add NA */
+  {COSTS_N_INSNS (0), COSTS_N_INSNS (0)},	/* fp_mul NA */
+  {COSTS_N_INSNS (0), COSTS_N_INSNS (0)},	/* fp_div NA */
+  {COSTS_N_INSNS (2), COSTS_N_INSNS (2)},	/* int_mul */
+  {COSTS_N_INSNS (3), COSTS_N_INSNS (3)},	/* int_div */
+  1,						/* issue_rate */
+  5,						/* branch_cost - theory says 4, 5 performs better 12/12/22 */
+  5,						/* memory_cost */
+  8,						/* fmv_cost */
+  true,						/* slow_unaligned_access */
+  false,					/* vector_unaligned_access */
+  false,					/* use_divmod_expansion */
+  false,					/* overlap_op_by_pieces */
+  RISCV_FUSE_NOTHING,                           /* fusible_ops */
+  NULL,						/* vector cost */
+  NULL,						/* function_align */
+  NULL,						/* jump_align */
+  NULL,						/* loop_align */
+};
+
+/* Costs to use when optimizing for qsr64.
+   HW latencies: multiply 2 cycles, divide variable 3-33 cycles 
+   (typically 3-8 for common 10-bit operands). */
+static const struct riscv_tune_param rvtt_qsr64_tune_info = {
+  {COSTS_N_INSNS (0), COSTS_N_INSNS (0)},	/* fp_add NA */
+  {COSTS_N_INSNS (0), COSTS_N_INSNS (0)},	/* fp_mul NA */
+  {COSTS_N_INSNS (0), COSTS_N_INSNS (0)},	/* fp_div NA */
+  {COSTS_N_INSNS (2), COSTS_N_INSNS (2)},	/* int_mul */
   {COSTS_N_INSNS (6), COSTS_N_INSNS (6)},	/* int_div */
   1,						/* issue_rate */
   5,						/* branch_cost - theory says 4, 5 performs better 12/12/22 */

--- a/gcc/testsuite/g++.target/tt/div-25192-bh.C
+++ b/gcc/testsuite/g++.target/tt/div-25192-bh.C
@@ -1,0 +1,101 @@
+// { dg-options "-mcpu=tt-bh -fno-exceptions -fno-rtti -O2" }
+// { dg-final { check-function-bodies "**" "" } }
+
+unsigned udiv3(unsigned n)  { return n / 3; }
+/*
+**_Z5udiv3j:
+**	li	a5,-1431654400
+**	addi	a5,a5,-1365
+**	mulhu	a0,a0,a5
+**	srli	a0,a0,1
+**	ret
+*/
+
+unsigned udiv7(unsigned n)  { return n / 7; }
+/*
+**_Z5udiv7j:
+**	li	a5,613568512
+**	addi	a5,a5,-1755
+**	mulhu	a5,a0,a5
+**	sub	a0,a0,a5
+**	srli	a0,a0,1
+**	add	a0,a0,a5
+**	srli	a0,a0,2
+**	ret
+*/
+
+unsigned udiv10(unsigned n) { return n / 10; }
+/*
+**_Z6udiv10j:
+**	li	a5,-858992640
+**	addi	a5,a5,-819
+**	mulhu	a0,a0,a5
+**	srli	a0,a0,3
+**	ret
+*/
+
+unsigned udiv100(unsigned n){ return n / 100; }
+/*
+**_Z7udiv100j:
+**	li	a5,1374388224
+**	addi	a5,a5,1311
+**	mulhu	a0,a0,a5
+**	srli	a0,a0,5
+**	ret
+*/
+
+int sdiv3(int n)  { return n / 3; }
+/*
+**_Z5sdiv3i:
+**	li	a5,1431654400
+**	addi	a5,a5,1366
+**	mulh	a5,a0,a5
+**	srai	a0,a0,31
+**	sub	a0,a5,a0
+**	ret
+*/
+
+int sdiv7(int n)  { return n / 7; }
+/*
+**_Z5sdiv7i:
+**	li	a5,-1840701440
+**	addi	a5,a5,1171
+**	mulh	a5,a0,a5
+**	srai	a4,a0,31
+**	add	a0,a0,a5
+**	srai	a0,a0,2
+**	sub	a0,a0,a4
+**	ret
+*/
+
+unsigned umod7(unsigned n) { return n % 7; }
+/*
+**_Z5umod7j:
+**	li	a4,613568512
+**	addi	a4,a4,-1755
+**	mulhu	a4,a0,a4
+**	sub	a5,a0,a4
+**	srli	a5,a5,1
+**	add	a5,a5,a4
+**	srli	a5,a5,2
+**	slli	a4,a5,3
+**	sub	a5,a4,a5
+**	sub	a0,a0,a5
+**	ret
+*/
+
+int smod7(int n)           { return n % 7; }
+/*
+**_Z5smod7i:
+**	li	a5,-1840701440
+**	addi	a5,a5,1171
+**	mulh	a5,a0,a5
+**	srai	a4,a0,31
+**	add	a5,a0,a5
+**	srai	a5,a5,2
+**	sub	a5,a5,a4
+**	slli	a4,a5,3
+**	sub	a5,a4,a5
+**	sub	a0,a0,a5
+**	ret
+*/

--- a/gcc/testsuite/g++.target/tt/div-25192-qsr32.C
+++ b/gcc/testsuite/g++.target/tt/div-25192-qsr32.C
@@ -1,0 +1,66 @@
+// { dg-options "-mcpu=tt-qsr32 -fno-exceptions -fno-rtti -O2" }
+// { dg-final { check-function-bodies "**" "" } }
+
+unsigned udiv3(unsigned n)  { return n / 3; }
+/*
+**_Z5udiv3j:
+**	li	a5,3
+**	divu	a0,a0,a5
+**	ret
+*/
+
+unsigned udiv7(unsigned n)  { return n / 7; }
+/*
+**_Z5udiv7j:
+**	li	a5,7
+**	divu	a0,a0,a5
+**	ret
+*/
+
+unsigned udiv10(unsigned n) { return n / 10; }
+/*
+**_Z6udiv10j:
+**	li	a5,10
+**	divu	a0,a0,a5
+**	ret
+*/
+
+unsigned udiv100(unsigned n){ return n / 100; }
+/*
+**_Z7udiv100j:
+**	li	a5,100
+**	divu	a0,a0,a5
+**	ret
+*/
+
+int sdiv3(int n)  { return n / 3; }
+/*
+**_Z5sdiv3i:
+**	li	a5,3
+**	div	a0,a0,a5
+**	ret
+*/
+
+int sdiv7(int n)  { return n / 7; }
+/*
+**_Z5sdiv7i:
+**	li	a5,7
+**	div	a0,a0,a5
+**	ret
+*/
+
+unsigned umod7(unsigned n) { return n % 7; }
+/*
+**_Z5umod7j:
+**	li	a5,7
+**	remu	a0,a0,a5
+**	ret
+*/
+
+int smod7(int n)           { return n % 7; }
+/*
+**_Z5smod7i:
+**	li	a5,7
+**	rem	a0,a0,a5
+**	ret
+*/

--- a/gcc/testsuite/g++.target/tt/div-25192-qsr64.C
+++ b/gcc/testsuite/g++.target/tt/div-25192-qsr64.C
@@ -1,0 +1,82 @@
+// { dg-options "-mcpu=tt-qsr64 -fno-exceptions -fno-rtti -O2" }
+// { dg-final { check-function-bodies "**" "" } }
+
+unsigned udiv3(unsigned n)  { return n / 3; }
+/*
+**_Z5udiv3j:
+**	li	a5,954437632
+**	zext.w	a0,a0
+**	sh1add	a5,a5,a5
+**	addi	a5,a5,-1365
+**	mul	a0,a0,a5
+**	srli	a0,a0,33
+**	ret
+*/
+
+unsigned udiv7(unsigned n)  { return n / 7; }
+/*
+**_Z5udiv7j:
+**	li	a5,7
+**	divuw	a0,a0,a5
+**	ret
+*/
+
+unsigned udiv10(unsigned n) { return n / 10; }
+/*
+**_Z6udiv10j:
+**	li	a5,1288491008
+**	zext.w	a0,a0
+**	bseti	a5,a5,31
+**	addi	a5,a5,-819
+**	mul	a0,a0,a5
+**	srli	a0,a0,35
+**	ret
+*/
+
+unsigned udiv100(unsigned n){ return n / 100; }
+/*
+**_Z7udiv100j:
+**	li	a5,1374388224
+**	zext.w	a0,a0
+**	addi	a5,a5,1311
+**	mul	a0,a0,a5
+**	srli	a0,a0,37
+**	ret
+*/
+
+int sdiv3(int n)  { return n / 3; }
+/*
+**_Z5sdiv3i:
+**	li	a5,1431654400
+**	addi	a5,a5,1366
+**	mul	a5,a0,a5
+**	sraiw	a0,a0,31
+**	srli	a5,a5,32
+**	subw	a0,a5,a0
+**	ret
+*/
+
+int sdiv7(int n)  { return n / 7; }
+/*
+**_Z5sdiv7i:
+**	li	a5,7
+**	divw	a0,a0,a5
+**	ret
+*/
+
+unsigned umod7(unsigned n) { return n % 7; }
+/*
+**_Z5umod7j:
+**	li	a5,7
+**	remuw	a0,a0,a5
+**	andi	a0,a0,7
+**	ret
+*/
+
+int smod7(int n)           { return n % 7; }
+/*
+**_Z5smod7i:
+**	li	a5,7
+**	remw	a0,a0,a5
+**	ret
+*/

--- a/gcc/testsuite/g++.target/tt/div-25192-wh.C
+++ b/gcc/testsuite/g++.target/tt/div-25192-wh.C
@@ -1,0 +1,101 @@
+// { dg-options "-mcpu=tt-wh -fno-exceptions -fno-rtti -O2" }
+// { dg-final { check-function-bodies "**" "" } }
+
+unsigned udiv3(unsigned n)  { return n / 3; }
+/*
+**_Z5udiv3j:
+**	li	a5,-1431654400
+**	addi	a5,a5,-1365
+**	mulhu	a0,a0,a5
+**	srli	a0,a0,1
+**	ret
+*/
+
+unsigned udiv7(unsigned n)  { return n / 7; }
+/*
+**_Z5udiv7j:
+**	li	a5,613568512
+**	addi	a5,a5,-1755
+**	mulhu	a5,a0,a5
+**	sub	a0,a0,a5
+**	srli	a0,a0,1
+**	add	a0,a0,a5
+**	srli	a0,a0,2
+**	ret
+*/
+
+unsigned udiv10(unsigned n) { return n / 10; }
+/*
+**_Z6udiv10j:
+**	li	a5,-858992640
+**	addi	a5,a5,-819
+**	mulhu	a0,a0,a5
+**	srli	a0,a0,3
+**	ret
+*/
+
+unsigned udiv100(unsigned n){ return n / 100; }
+/*
+**_Z7udiv100j:
+**	li	a5,1374388224
+**	addi	a5,a5,1311
+**	mulhu	a0,a0,a5
+**	srli	a0,a0,5
+**	ret
+*/
+
+int sdiv3(int n)  { return n / 3; }
+/*
+**_Z5sdiv3i:
+**	li	a5,1431654400
+**	addi	a5,a5,1366
+**	mulh	a5,a0,a5
+**	srai	a0,a0,31
+**	sub	a0,a5,a0
+**	ret
+*/
+
+int sdiv7(int n)  { return n / 7; }
+/*
+**_Z5sdiv7i:
+**	li	a5,-1840701440
+**	addi	a5,a5,1171
+**	mulh	a5,a0,a5
+**	srai	a4,a0,31
+**	add	a0,a0,a5
+**	srai	a0,a0,2
+**	sub	a0,a0,a4
+**	ret
+*/
+
+unsigned umod7(unsigned n) { return n % 7; }
+/*
+**_Z5umod7j:
+**	li	a4,613568512
+**	addi	a4,a4,-1755
+**	mulhu	a4,a0,a4
+**	sub	a5,a0,a4
+**	srli	a5,a5,1
+**	add	a5,a5,a4
+**	srli	a5,a5,2
+**	slli	a4,a5,3
+**	sub	a5,a4,a5
+**	sub	a0,a0,a5
+**	ret
+*/
+
+int smod7(int n)           { return n % 7; }
+/*
+**_Z5smod7i:
+**	li	a5,-1840701440
+**	addi	a5,a5,1171
+**	mulh	a5,a0,a5
+**	srai	a4,a0,31
+**	add	a5,a0,a5
+**	srai	a5,a5,2
+**	sub	a5,a5,a4
+**	slli	a4,a5,3
+**	sub	a5,a4,a5
+**	sub	a0,a0,a5
+**	ret
+*/


### PR DESCRIPTION
Create new tuning profiles for different architectures, GCC will automatically infer mutiply/shift chain if the cost is lower than a division operation.
<!-- CI: https://github.com/tenstorrent/tt-metal/actions/runs/24871096476 -->

BH post commit test: https://github.com/tenstorrent/tt-metal/actions/runs/25004628928
 - failures exist on main without my change too: https://github.com/tenstorrent/tt-metal/actions/runs/24994820813

Sanity tests: https://github.com/tenstorrent/tt-metal/actions/runs/25004677763
PR gate: https://github.com/tenstorrent/tt-metal/actions/runs/25004712056
Merge gate: https://github.com/tenstorrent/tt-metal/actions/runs/25004752880