### PR TITLE
gcc/config/riscv/tt: fix unlink_stmt_vdef called after gsi_remove in try_combine_negated_result

### DIFF
--- a/gcc/config/riscv/tt/gimple-rvtt-combine.cc
+++ b/gcc/config/riscv/tt/gimple-rvtt-combine.cc
@@ -797,8 +797,8 @@ try_combine_negated_result (probe_t &probe)
   release_ssa_name (gimple_call_lhs (input.call));
   gimple_call_set_lhs (input.call, gimple_call_lhs (probe.call));
 
-  gsi_remove (&probe.gsi, true);
   unlink_stmt_vdef (probe.call);
+  gsi_remove (&probe.gsi, true);
   gsi_prev (&probe.gsi);
 
   return true;


### PR DESCRIPTION
In `try_combine_negated_result`, `unlink_stmt_vdef (probe.call)` was
called after `gsi_remove (&probe.gsi, true)`, leaving the virtual
operand chain unlinked only after the statement had already been removed
from the basic block.  This is a use-after-remove: `gsi_remove` with
`purge=true` unlinks the statement and may free it, so accessing
`probe.call`'s vdef chain afterwards can corrupt the SSA virtual operand
graph or read stale memory.

Every other removal site in this file follows the canonical order:
`unlink_stmt_vdef` → `gsi_remove` → `release_defs` (lines 355-356,
505-506, 539-540, 631-632, 750-751, 864-865).  Lines 800-801 were the
sole exception — a transposition of the two calls.

Fix by swapping the two lines so `unlink_stmt_vdef` precedes
`gsi_remove`, consistent with all other deletion sites in this pass.

gcc/config/riscv/tt/gimple-rvtt-combine.cc
	(try_combine_negated_result): Call unlink_stmt_vdef before
	gsi_remove, not after.