### PR TITLE
rtl-rvtt-replay: use data() for one-past-end pointer arithmetic

### DIFF
--- a/gcc/config/riscv/tt/rtl-rvtt-replay.cc
+++ b/gcc/config/riscv/tt/rtl-rvtt-replay.cc
@@ -412,7 +412,7 @@ static void
 dump_sequence (FILE *stream, replay_block const &block, replay_span span,
 	       unsigned base, bool ignore_empty = true)
 {
-  for (auto pos = &block[span.begin], end = &block[span.end];
+  for (auto pos = block.data () + span.begin, end = block.data () + span.end;
        pos != end; pos++)
     {
       if (ignore_empty && pos->empty)
@@ -517,8 +517,8 @@ replace_sequence (replay_sequence &seq, replay_block &block, unsigned replay_sta
   emit_insn_before (capture, block[seq.clones.front ().begin].insn);
 
   // Make sure we've not deleted anything in this instance already
-  for (auto pos = &block[seq.clones.front ().begin],
-	 end = &block[seq.clones.front ().end];
+  for (auto pos = block.data () + seq.clones.front ().begin,
+	 end = block.data () + seq.clones.front ().end;
        pos != end; pos++)
     gcc_assert (GET_CODE (pos->insn) == INSN);
 
@@ -537,7 +537,7 @@ replace_sequence (replay_sequence &seq, replay_block &block, unsigned replay_sta
       if (not_quasar_fix)
 	{
 	  unsigned ix = replay_start;
-	  for (auto pos = &block[clone->begin], end = &block[clone->end];
+	  for (auto pos = block.data () + clone->begin, end = block.data () + clone->end;
 	       pos != end; pos++)
 	    {
 	      if (dump_file)


### PR DESCRIPTION
## Summary

`block[span.end]` where `span.end == block.size()` is undefined behaviour and triggers `_GLIBCXX_ASSERTIONS` on hosts built with GCC 16's hardened libstdc++, causing an ICE in the `rvtt_replay` pass:

```
stl_vector.h:1253: Assertion '__n < this->size()' failed.
during RTL pass: rvtt_replay
internal compiler error: Aborted
```

This manifests on every test file that uses `#pragma GCC unroll` with SFPI builtins (all six `lut-35315-{bh,qsr,wh}.C` and `replay-34602-{bh,qsr,wh}.C`), because after unrolling a sequence of `N` insns ends exactly at `block.size()`.

## Fix

Replace `&block[span.end]` with `block.data() + span.end` in the three range-loop initialisers inside `dump_sequence` and `replace_sequence`. `data() + size()` is a well-defined one-past-end pointer; `operator[](size())` is not.

## Test plan

- [ ] All 845 tensix tests pass (`make check-gcc-tt`) with no unexpected failures after the fix, on an aarch64 host with GCC 16 + hardened libstdc++
- [ ] Previously: 12 FAILs + 30 UNRESOLVEDs (all ICE) → now: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)